### PR TITLE
Bug Report - Inconsistent Image Slider Size (Update location.php)

### DIFF
--- a/public/location.php
+++ b/public/location.php
@@ -26,7 +26,7 @@
 
         <!-- Image Slider Container -->
         <section class="img-slider h-[35rem]">
-            <div id="carousel" class="w-full h-[26rem] carousel slide relative" data-bs-ride="carousel">
+            <div id="carousel" class="w-full carousel slide relative" data-bs-ride="carousel">
                 <div class="carousel-indicators absolute right-0 top-[36rem] left-0 flex justify-center p-0 mt-4">
                     <button
                     type="button"


### PR DESCRIPTION
**Description:**
Visual outputs for the Image Slider are inconsistent between different window sizes. Browsers showing the same display are the following:
   • Google Chrome
   • Safari
   • Mozilla
   • Edge

**Steps to Reproduce:**
1. Open the [live website](https://wanderlust.maijomade.com/public/index.php) in Google Chrome, Safari, Mozilla, and Edge.
2. Navigate to "User Recommendations" section.
3. Open one Location card to open its Information Page.
4. On that page, reduce and enlarge the browser window width.

**Expected Result:**
Visual output formats of the Image Slider must be visually consistent for different window sizes.

**Actual Result:**
Visual output inconsistencies are evident in different window sizes. Either resulting whitespace in between the Image Slider and the h1 title, or the two assets overlapping together.

_Mac M1, Google Chrome, Screenshot 1 (Half-screen Size)_
<img width="863" alt="Screenshot 2022-12-04 at 2 56 51 PM" src="https://user-images.githubusercontent.com/116108360/205520611-52a7a5c1-f1cb-479f-9930-aeaacaa1ac43.png">

_Mac M1, Google Chrome, Screenshot 2 (Fullscreen Size)_
<img width="1728" alt="Screenshot 2022-12-04 at 2 38 07 PM" src="https://user-images.githubusercontent.com/116108360/205519685-35eb1ddb-f066-4750-97ce-95548c236566.png">

**Severity:**
Medium

**Priority:**
Low